### PR TITLE
MANTA-2862 Manta should include HTTP Strict Transport Security header

### DIFF
--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -45,10 +45,12 @@ backend haproxy-stats_http
 frontend https
         bind 127.0.0.1:8443 accept-proxy
         default_backend secure_api
+        http-response set-header Strict-Transport-Security max-age=15768000;\ includeSubDomains;\ preload;
 
 frontend http_external
         bind %s:80
         default_backend insecure_api
+        http-response set-header Strict-Transport-Security max-age=15768000;\ includeSubDomains;\ preload;
 
 
 frontend http_internal


### PR DESCRIPTION
I don't have a manta test set up, but I set up base64 14.2.0 instance with stud and haproxy from pkgsrc, and dropped nginx into the backend to spoof Manta.

Basic checks with curl work and the header is included as expected.