### PR TITLE
MANTA-4629 add Jenkinsfiles to Manta repositories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+@Library('jenkins-joylib@v1.0.1') _
+
+pipeline {
+
+    agent {
+        label joyCommonLabels(image_ver: '18.4.0')
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+        timestamps()
+    }
+
+    stages {
+        stage('check') {
+            steps{
+                sh('make check')
+            }
+        }
+        // this may involve effectively building twice,
+        // but the build is fast, so perhaps acceptable.
+        stage('test') {
+            steps{
+                sh('make test')
+            }
+        }
+        // avoid bundling devDependencies
+        stage('re-clean') {
+            steps {
+                sh('git clean -fdx')
+            }
+        }
+        stage('build image and upload') {
+            steps {
+                joyBuildImageAndUpload()
+            }
+        }
+    }
+
+    post {
+        always {
+            joyMattermostNotification(channel: 'jenkins')
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request differs from other Manta-related Jenkinsfile changes, in that we also execute the test suite prior to building.