### PR TITLE
MANTA-4784 nightly muppet testing needs work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 /build
 docs/*.json
 docs/*.html
-etc/haproxy.cfg
 cscope.in.out
 cscope.po.out
 cscope.out
 smf/manifests/*.xml
+test/haproxy.cfg
 /*.tar.gz

--- a/lib/lb_manager.js
+++ b/lib/lb_manager.js
@@ -66,7 +66,6 @@ const jsprim = require('jsprim');
 ///--- Globals
 
 const CFG_FILE = path.resolve(__dirname, '../etc/haproxy.cfg');
-const CFG_FILE_TMP = path.resolve(__dirname, '../etc/haproxy.cfg.tmp');
 const CFG_TEMPLATE = fs.readFileSync(
     path.resolve(__dirname, '../etc/haproxy.cfg.in'), 'utf8');
 const HAPROXY_FMRI = 'svc:/manta/haproxy:default';
@@ -309,6 +308,7 @@ function checkHaproxyConfig(opts, cb) {
  * - servers, backend server addresses to forward requests to
  * - reload (optional), the command to run to reload HAProxy config
  * - configTemplate (optional), the haproxy config template
+ * - configFile (optional), the haproxy output file
  * - log, a Bunyan logger
  */
 function reload(opts, cb) {
@@ -321,6 +321,7 @@ function reload(opts, cb) {
     assert.func(cb, 'callback');
     // For testing
     assert.optionalString(opts.configTemplate, 'options.configTemplate');
+    assert.optionalString(opts.configFile, 'options.configFile');
     assert.optionalString(opts.reload, 'options.reload');
 
     opts.log.debug({servers: opts.servers}, 'reload requested');
@@ -342,20 +343,25 @@ function reload(opts, cb) {
          * - Rename temporary file to final file once check passes
          * - Tell haproxy to reload with the known-good config file
          */
-        opts.configFile = CFG_FILE_TMP;
-
         if (opts.configTemplate === undefined) {
             opts.configTemplate = CFG_TEMPLATE;
         }
+
+        var configFile = opts.configFile;
+        if (configFile === undefined) {
+            configFile = CFG_FILE;
+        }
+
+        opts.configFile = configFile + '.tmp';
 
         vasync.pipeline({ arg: opts, funcs: [
             writeHaproxyConfig,
             checkHaproxyConfig,
             function finalRenameConfig(arg, callback) {
                 arg.log.debug('Renaming haproxy config file: %s to %s',
-                    arg.configFile, CFG_FILE);
+                    arg.configFile, configFile);
 
-                return (fs.rename(arg.configFile, CFG_FILE, callback));
+                return (fs.rename(arg.configFile, configFile, callback));
             },
             function finalReload(arg, callback) {
                 reloadHaproxy({log: arg.log, reload: arg.reload}, callback);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -33,8 +33,7 @@ const haproxy_template = fs.readFileSync(
     path.resolve(__dirname, 'haproxy.cfg.in'), 'utf8');
 
 // Files that the successful reload test will write out
-var haproxy_file = path.resolve(__dirname, '../etc/haproxy.cfg');
-var haproxy_file_tmp = path.resolve(__dirname, '../etc/haproxy.cfg.tmp');
+var haproxy_file = path.resolve(__dirname, 'haproxy.cfg');
 
 var haproxy_exec = path.resolve(__dirname, '../build/haproxy/sbin/haproxy');
 
@@ -158,6 +157,7 @@ tap.test('test reload', function (t) {
         servers: { 'foo.joyent.us': { address: '127.0.0.1' } },
         reload: '/bin/true',
         haproxyExec: haproxy_exec,
+        configFile: haproxy_file,
         configTemplate: haproxy_template,
         log: helper.createLogger()
     };
@@ -184,6 +184,7 @@ tap.test('test reload bad config (should error)', function (t) {
         servers: {},
         reload: '/bin/true',
         haproxyExec: haproxy_exec,
+        configFile: haproxy_file,
         configTemplate: haproxy_template,
         log: helper.createLogger()
     };
@@ -209,6 +210,7 @@ tap.test('test dueling reloads', function (t) {
         },
         reload: '/bin/sleep 2',
         haproxyExec: haproxy_exec,
+        configFile: haproxy_file,
         configTemplate: haproxy_template,
         log: helper.createLogger()
     };
@@ -220,6 +222,7 @@ tap.test('test dueling reloads', function (t) {
         servers: { 'foo.joyent.us': { kind: 'webapi', address: '127.0.0.1' } },
         reload: '/bin/true',
         haproxyExec: haproxy_exec,
+        configFile: haproxy_file,
         configTemplate: haproxy_template,
         log: helper.createLogger()
     };


### PR DESCRIPTION
Hi Trent, further testing uncovered that when we run make test on an installed muppet, we were accidentally over-write the etc/haproxy.cfg with the test one. This fixes this up.
Tested with the new nightly-theatre changes. Apologies for the extra noise, and let me know if you'd prefer somebody else to look at this too.