### PR TITLE
MANTA-4875 Allow muppet haproxy metrics to be exposed through cmon by default

### DIFF
--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -7,7 +7,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 set -o xtrace
@@ -26,11 +26,27 @@ export PATH=$SVC_ROOT/build/node/bin:/opt/local/bin:/usr/sbin/:/usr/bin:$PATH
 
 MUPPET_CFG=$SVC_ROOT/etc/config.json
 
+#
+# This is an arbitrary value
+#
+METRICS_PORT=9090
 
 function manta_setup_muppet {
-    svccfg import /opt/smartdc/muppet/smf/manifests/muppet.xml
-    svcadm enable muppet
-    [[ $? -eq 0 ]] || fatal "Unable to start muppet"
+    local metrics_port=${METRICS_PORT}
+    local muppet_smf_xml_manifest_in="${SVC_ROOT}/smf/manifests/muppet.xml.in"
+    local muppet_smf_xml_manifest_out="${SVC_ROOT}/smf/manifests/muppet.xml"
+
+    sed -e "s#@@MUPPET-METRICS_PORT@@#$metrics_port#g" \
+        ${muppet_smf_xml_manifest_in} > ${muppet_smf_xml_manifest_out} || \
+        fatal "Could not process ${muppet_smf_xml_manifest_in} to ${muppet_smf_xml_manifest_out}"
+
+    svccfg import ${muppet_smf_xml_manifest_out} || \
+        fatal "Could not import: ${muppet_smf_xml_manifest_out}"
+
+    svcadm enable muppet || \
+        fatal "Unable to start muppet"
+
+    mdata-put metricPorts ${metrics_port}
 }
 
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -53,14 +53,6 @@ const SETUP_RETRY_TIMEOUT = 30000;
 const BESTATE_DOUBLECHECK = 30000;
 const MAX_DIRTY_TIME = 6*3600*1000;
 
-/*
- * XXX: For now METRICS_PORT is set to an arbitrary value > 1024. We need
- * to revisit this decision in the future and set "metricPorts" in instance
- * metadata, similar to what binder does. This way cmon-agent can discover
- * the metrics port automatically.
- */
-const METRICS_PORT = 12321;
-
 function AppFSM(cfg) {
     this.a_log = cfg.log;
 
@@ -79,15 +71,16 @@ function AppFSM(cfg) {
 
     this.a_reloadCmd = cfg.reload;
 
-    cfg.metricsPort = METRICS_PORT;
-    cfg.haSock = lib_hasock;
-    this.a_metricsExporter = lib_metrics.createMetricsExporter(cfg);
-    this.a_metricsExporter.start(function (_err) {
-        /*
-         * The metric server is not a critical component of muppet.
-         * If it has failed to start, we would log the error and continue.
-         */
-    });
+    if (cfg.metricsPort) {
+        cfg.haSock = lib_hasock;
+        this.a_metricsExporter = lib_metrics.createMetricsExporter(cfg);
+        this.a_metricsExporter.start(function (err) {
+            if (err) {
+                cfg.log.fatal(err, 'failed to start metrics server');
+                process.exit(1);
+            }
+        });
+    }
 
     FSM.call(this, 'getips');
 }

--- a/lib/metrics_exporter.js
+++ b/lib/metrics_exporter.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 
@@ -684,9 +684,9 @@ function MetricsExporter(opts) {
     mod_assert.object(opts, 'opts');
     mod_assert.object(opts.log, 'opts.log');
     mod_assert.object(opts.haSock, 'opts.haSock');
-    mod_assert.arrayOfString(opts.mantaIPS, 'opts.mantaIPS');
+    mod_assert.arrayOfString(opts.adminIPS, 'opts.adminIPS');
     mod_assert.number(opts.metricsPort, 'opts.metricsPort');
-    mod_assert.ok(opts.mantaIPS.length > 0, 'opts.mantaIPS.length > 0');
+    mod_assert.ok(opts.adminIPS.length > 0, 'opts.adminIPS.length > 0');
 
 
     var self = this;
@@ -733,7 +733,7 @@ function MetricsExporter(opts) {
 
     // Register /metrics handler
     self.server.get('/metrics', getMetricsHandler);
-    self.address = opts.mantaIPS[0];
+    self.address = opts.adminIPS[0];
     self.port = opts.metricsPort;
 }
 

--- a/muppet.js
+++ b/muppet.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -47,6 +47,12 @@ function configure() {
             type: 'string',
             help: 'File to process',
             helpArg: 'FILE'
+        },
+        {
+            names: ['metricsPort', 'm'],
+            type: 'integer',
+            help: 'Metrics port',
+            helpArg: 'PORT'
         }
     ];
 
@@ -96,6 +102,22 @@ function configure() {
 
     if (cfg.logLevel)
         log.level(cfg.logLevel);
+
+    var MIN_USER_PORT = 1024;
+    var MAX_USER_PORT = 49151;
+
+    if (opts.metricsPort) {
+        if (opts.metricsPort < MIN_USER_PORT ||
+            opts.metricsPort > MAX_USER_PORT) {
+
+            log.fatal('invalid metrics port specified: %s. ' +
+                'Please specify a valid port in the range [%d - %d]',
+                opts.metricsPort, MIN_USER_PORT, MAX_USER_PORT);
+            process.exit(1);
+        }
+
+        cfg.metricsPort = opts.metricsPort;
+    }
 
     if (opts.verbose) {
         opts.verbose.forEach(function () {

--- a/smf/manifests/muppet.xml.in
+++ b/smf/manifests/muppet.xml.in
@@ -7,7 +7,7 @@
 -->
 
 <!--
-    Copyright (c) 2019, Joyent, Inc.
+    Copyright 2020 Joyent, Inc.
 -->
 
 <service_bundle type="manifest" name="muppet">
@@ -45,7 +45,7 @@
 
 	<exec_method type="method"
 		     name="start"
-		     exec="node --abort-on-uncaught-exception muppet.js -f ./etc/config.json &amp;"
+		     exec="node --abort-on-uncaught-exception muppet.js -f ./etc/config.json -m %{muppet/metrics-port} &amp;"
 		     timeout_seconds="30">
 	    <method_context working_directory="/opt/smartdc/muppet">
                 <method_credential user="root"
@@ -64,6 +64,10 @@
 		     name="stop"
 		     exec=":kill"
 		     timeout_seconds="30" />
+
+  <property_group name="muppet" type="application">
+      <propval name="metrics-port" type="astring" value="@@MUPPET-METRICS_PORT@@" />
+  </property_group>
 
 	<template>
 	    <common_name>

--- a/test/metrics_exports.test.js
+++ b/test/metrics_exports.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*jsl:ignore*/
@@ -33,7 +33,7 @@ tap.afterEach(function (cb, t) {
 tap.test('start and close metrics server', function (t) {
     var opts = {
         log: bunyan.createLogger({ name: 'dummy' }),
-        mantaIPS: ['127.0.0.1'],
+        adminIPS: ['127.0.0.1'],
         metricsPort: 12421,
         haSock: lib_hasock
     };
@@ -57,7 +57,7 @@ const NUMBER_REG_EXP =
 tap.test('metrics server is producing valid metrics', function (t) {
     var opts = {
         log: bunyan.createLogger({ name: 'dummy' }),
-        mantaIPS: ['127.0.0.1'],
+        adminIPS: ['127.0.0.1'],
         metricsPort: 12421,
         haSock: lib_hasock
     };
@@ -99,7 +99,7 @@ tap.test('metrics server is producing valid metrics', function (t) {
 
         var body = '';
         var reqOpts = {
-            host: opts.mantaIPS[0],
+            host: opts.adminIPS[0],
             port: opts.metricsPort,
             path: '/metrics'
         };


### PR DESCRIPTION
This is a port of [PR#18](https://github.com/joyent/muppet/pull/18). I updating nothing but the copyright year for `make check` to pass.
