### PR TITLE
MANTA-5456 loadbalancer needs to update haproxy dependency past CVE-2021-40346

### DIFF
--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -62,6 +62,11 @@ backend haproxy-stats_http
 
 frontend https
         http-request capture req.hdr(x-request-id) len 36
+
+        # Protect against CVE-2021-40346
+        http-request  deny if { req.hdr_cnt(content-length) gt 1 }
+        http-response deny if { res.hdr_cnt(content-length) gt 1 }
+
         acl acl_bucket path_reg ^/[^/]+/buckets
         # force a 404 response in mantav1
         # use_backend buckets_api if acl_bucket

--- a/lib/lb_manager.js
+++ b/lib/lb_manager.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 /*
@@ -71,8 +71,14 @@ const CFG_TEMPLATE = fs.readFileSync(
 const HAPROXY_FMRI = 'svc:/manta/haproxy:default';
 const RELOAD = '/usr/sbin/svcadm refresh ' + HAPROXY_FMRI;
 
-const HTTP_FRONTEND =
-    'frontend http_external\n        default_backend insecure_api\n';
+var HTTP_FRONTEND = '';
+HTTP_FRONTEND += 'frontend http_external\n';
+HTTP_FRONTEND += '        default_backend insecure_api\n';
+HTTP_FRONTEND += '        # Protect against CVE-2021-40346\n';
+/*JSSTYLED*/
+HTTP_FRONTEND += '        http-request  deny if { req.hdr_cnt(content-length) gt 1 }\n';
+/*JSSTYLED*/
+HTTP_FRONTEND += '        http-response deny if { res.hdr_cnt(content-length) gt 1 }\n';
 const HTTP_BIND_LINE = '        bind %s:80\n';
 
 var reload_queue = vasync.queue(function (f, cb) { f(cb); }, 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "muppet",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muppet",
   "description": "Joyent's Load Balancer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Same as #35, but this is for v1.