### PR TITLE
MANTA-5473 S3 Support for Presigned URLs

### DIFF
--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -72,6 +72,25 @@ frontend https
         # we will have to revisit this section.
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
+        
+        # AWS S3 presigned URLs - route to buckets_api based on query parameters
+        acl acl_s3_presigned urlp(X-Amz-Algorithm) -m found
+        acl acl_s3_presigned_alt urlp(X-Amz-Signature) -m found
+        acl acl_s3_credential urlp(X-Amz-Credential) -m found
+        
+        # S3-style bucket/object paths detection
+        acl acl_s3_path path_reg ^/[^/]+/[^/]
+        acl acl_not_manta_user path_reg -v ^/[^/]+/(jobs|stor|public|reports|uploads)/
+        
+        # Route S3 requests with explicit S3 authentication
+        use_backend buckets_api if acl_s3_presigned
+        use_backend buckets_api if acl_s3_presigned_alt  
+        use_backend buckets_api if acl_s3_credential
+        
+        # Only route S3-style paths if they have S3 authentication
+        use_backend buckets_api if acl_s3_path acl_not_manta_user acl_aws_sigv4
+        use_backend buckets_api if acl_s3_path acl_not_manta_user acl_s3_presigned
+        use_backend buckets_api if acl_s3_path acl_not_manta_user acl_s3_credential
 
         # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -70,7 +70,7 @@ frontend https
         # AWS S3 API compatibility - route SigV4 requests to buckets_api
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
-        
+
         # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets
         use_backend buckets_api if acl_bucket

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -68,6 +68,8 @@ frontend https
         http-response deny if { res.hdr_cnt(content-length) gt 1 }
 
         # AWS S3 API compatibility - route SigV4 requests to buckets_api
+        # If for some reason any other back end uses SigV4 in the future,
+        # we will have to revisit this section.
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
 

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -72,25 +72,11 @@ frontend https
         # we will have to revisit this section.
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
-        
         # AWS S3 presigned URLs - route to buckets_api based on query parameters
         acl acl_s3_presigned urlp(X-Amz-Algorithm) -m found
         acl acl_s3_presigned_alt urlp(X-Amz-Signature) -m found
-        acl acl_s3_credential urlp(X-Amz-Credential) -m found
-        
-        # S3-style bucket/object paths detection
-        acl acl_s3_path path_reg ^/[^/]+/[^/]
-        acl acl_not_manta_user path_reg -v ^/[^/]+/(jobs|stor|public|reports|uploads)/
-        
-        # Route S3 requests with explicit S3 authentication
         use_backend buckets_api if acl_s3_presigned
-        use_backend buckets_api if acl_s3_presigned_alt  
-        use_backend buckets_api if acl_s3_credential
-        
-        # Only route S3-style paths if they have S3 authentication
-        use_backend buckets_api if acl_s3_path acl_not_manta_user acl_aws_sigv4
-        use_backend buckets_api if acl_s3_path acl_not_manta_user acl_s3_presigned
-        use_backend buckets_api if acl_s3_path acl_not_manta_user acl_s3_credential
+        use_backend buckets_api if acl_s3_presigned_alt
 
         # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -67,6 +67,11 @@ frontend https
         http-request  deny if { req.hdr_cnt(content-length) gt 1 }
         http-response deny if { res.hdr_cnt(content-length) gt 1 }
 
+        # AWS S3 API compatibility - route SigV4 requests to buckets_api
+        acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
+        use_backend buckets_api if acl_aws_sigv4
+        
+        # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets
         use_backend buckets_api if acl_bucket
         default_backend secure_api

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -72,11 +72,14 @@ frontend https
         # we will have to revisit this section.
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
-        # AWS S3 presigned URLs - route to buckets_api based on query parameters
-        acl acl_s3_presigned urlp(X-Amz-Algorithm) -m found
-        acl acl_s3_presigned_alt urlp(X-Amz-Signature) -m found
-        use_backend buckets_api if acl_s3_presigned
-        use_backend buckets_api if acl_s3_presigned_alt
+        # AWS S3 SigV4 presigned URLs - route to buckets_api
+        acl acl_s3_presigned_v4 query -m reg ".*X-Amz-Algorithm.*"
+        use_backend buckets_api if acl_s3_presigned_v4
+        # AWS S3 CORS preflight requests - route OPTIONS to buckets_api for S3 paths
+        acl acl_s3_cors_preflight method OPTIONS
+        acl acl_s3_cors_preflight req.hdr(access-control-request-method) -m found
+        acl acl_s3_path path_reg ^/[^/]+(/.*)?(\?.*)?$
+        use_backend buckets_api if acl_s3_cors_preflight acl_s3_path
 
         # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muppet",
   "description": "Manta's Load Balancer",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muppet",
   "description": "Manta's Load Balancer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Muppet must route pre-signed requests to the Manta S3 compatibility layer.